### PR TITLE
Scan only runtime dependencies

### DIFF
--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -96,6 +96,9 @@ def run(nvd, store):
 @click.option('-r/-R', '--requisites/--no-requisites', default=True,
               help='Yes: determine transitive closure. No: examine just the '
               'passed derivations (default: yes).')
+@click.option('--runtime', is_flag=True,
+              help='Examine only runtime dependencies (default: no). '
+              'Implies --no-requisites.')
 @click.option('-m', '--mirror',
               help='Mirror to fetch NVD archives from. Default: {}.'.format(
                   DEFAULT_MIRROR),
@@ -115,11 +118,15 @@ def run(nvd, store):
 @click.option('-F', '--notfixed', is_flag=True,
               help='(obsolete; kept for compatibility reasons)')
 def main(verbose, gc_roots, system, from_file, profile, path, mirror,
-         cache_dir, requisites, whitelist, write_whitelist, version, json,
-         show_whitelisted, show_description, default_whitelist, notfixed):
+         cache_dir, requisites, runtime, whitelist, write_whitelist,
+         version, json, show_whitelisted, show_description,
+         default_whitelist, notfixed):
     if version:
         print('vulnix ' + pkg_resources.get_distribution('vulnix').version)
         sys.exit(0)
+
+    if (runtime):
+        requisites = False
 
     if not (gc_roots or system or profile or path or from_file):
         howto()
@@ -138,7 +145,7 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
             for wl in wh_sources:
                 whitelist.merge(Whitelist.load(wl))
         with Timer('Load derivations'):
-            store = Store(requisites)
+            store = Store(requisites, runtime)
             if from_file:
                 if from_file.name.endswith('.json'):
                     _log.debug("loading packages.json")

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -50,7 +50,7 @@ def init_logging(verbose):
         logging.basicConfig(level=logging.WARNING)
 
 
-def populate_store(store, gc_roots, profiles, paths, requisites=True):
+def populate_store(store, gc_roots, profiles, paths):
     """Load derivations from nix store depending on cmdline invocation."""
     if gc_roots:
         store.add_gc_roots()
@@ -147,7 +147,7 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
                     for drv in from_file.readlines():
                         paths.append(drv.strip())
             else:
-                populate_store(store, gc_roots, profile,  paths, requisites)
+                populate_store(store, gc_roots, profile,  paths)
         with NVD(mirror, cache_dir) as nvd:
             with Timer('Update NVD data'):
                 nvd.update()

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -96,7 +96,7 @@ def run(nvd, store):
 @click.option('-r/-R', '--requisites/--no-requisites', default=True,
               help='Yes: determine transitive closure. No: examine just the '
               'passed derivations (default: yes).')
-@click.option('--closure', is_flag=True,
+@click.option('-C', '--closure', is_flag=True,
               help='Examine the closure of an output path '
               '(runtime dependencies). Implies --no-requisites.')
 @click.option('-m', '--mirror',

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -96,9 +96,9 @@ def run(nvd, store):
 @click.option('-r/-R', '--requisites/--no-requisites', default=True,
               help='Yes: determine transitive closure. No: examine just the '
               'passed derivations (default: yes).')
-@click.option('--runtime', is_flag=True,
-              help='Examine only runtime dependencies (default: no). '
-              'Implies --no-requisites.')
+@click.option('--closure', is_flag=True,
+              help='Examine the closure of an output path '
+              '(runtime dependencies). Implies --no-requisites.')
 @click.option('-m', '--mirror',
               help='Mirror to fetch NVD archives from. Default: {}.'.format(
                   DEFAULT_MIRROR),
@@ -118,14 +118,14 @@ def run(nvd, store):
 @click.option('-F', '--notfixed', is_flag=True,
               help='(obsolete; kept for compatibility reasons)')
 def main(verbose, gc_roots, system, from_file, profile, path, mirror,
-         cache_dir, requisites, runtime, whitelist, write_whitelist,
+         cache_dir, requisites, closure, whitelist, write_whitelist,
          version, json, show_whitelisted, show_description,
          default_whitelist, notfixed):
     if version:
         print('vulnix ' + pkg_resources.get_distribution('vulnix').version)
         sys.exit(0)
 
-    if (runtime):
+    if (closure):
         requisites = False
 
     if not (gc_roots or system or profile or path or from_file):
@@ -145,7 +145,7 @@ def main(verbose, gc_roots, system, from_file, profile, path, mirror,
             for wl in wh_sources:
                 whitelist.merge(Whitelist.load(wl))
         with Timer('Load derivations'):
-            store = Store(requisites, runtime)
+            store = Store(requisites, closure)
             if from_file:
                 if from_file.name.endswith('.json'):
                     _log.debug("loading packages.json")

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -109,14 +109,19 @@ class Store(object):
         if self.closure:
             for output in self._find_outputs(path):
                 for candidate in map(
-                    # Nix 2.4 also returns a `deriver` field
-                    # but like `nix-store -qd` that path may not exist
-                    lambda p: self._find_deriver(p.get('path')),
+                    # We cannot use the `deriver` field because
+                    # like `nix-store -qd` that path may not exist.
+                    # However, we know that if it is not present
+                    # the path has no deriver because it is a
+                    # derivation input source so we can skip it.
+                    lambda p: self._find_deriver(p.get('path'))
+                        if p.get('deriver') is not None else None,
                     json.loads(
                         self._call_nix(['path-info', '-r', '--json', output])
                     )
                 ):
-                    self.update(candidate)
+                    if candidate is not None:
+                        self.update(candidate)
         else:
             deriver = self._find_deriver(path)
             if self.requisites:

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -9,9 +9,9 @@ _log = logging.getLogger(__name__)
 
 class Store(object):
 
-    def __init__(self, requisites=True, runtime=False):
+    def __init__(self, requisites=True, closure=False):
         self.requisites = requisites
-        self.runtime = runtime
+        self.closure = closure
         self.derivations = set()
         self.experimental_flag_needed = None
 
@@ -106,7 +106,7 @@ class Store(object):
                                'derivations referenced from it'.format(path))
         _log.debug('Loading derivations referenced by "%s"', path)
 
-        if self.runtime:
+        if self.closure:
             for output in self._find_outputs(path):
                 for candidate in map(
                     # Nix 2.4 also returns `p.get('deriver')`

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -109,8 +109,8 @@ class Store(object):
         if self.closure:
             for output in self._find_outputs(path):
                 for candidate in map(
-                    # Nix 2.4 also returns `p.get('deriver')`
-                    # like `nix-store -qd` but that path may not exist
+                    # Nix 2.4 also returns a `deriver` field
+                    # but like `nix-store -qd` that path may not exist
                     lambda p: self._find_deriver(p.get('path')),
                     json.loads(
                         self._call_nix(['path-info', '-r', '--json', output])

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -9,8 +9,9 @@ _log = logging.getLogger(__name__)
 
 class Store(object):
 
-    def __init__(self, requisites=True):
+    def __init__(self, requisites=True, runtime=False):
         self.requisites = requisites
+        self.runtime = runtime
         self.derivations = set()
         self.experimental_flag_needed = None
 
@@ -86,18 +87,45 @@ class Store(object):
             'Cannot determine deriver. Is this really a path into the '
             'nix store?', path)
 
+    def _find_outputs(self, path):
+        if not path.endswith('.drv'):
+            return [path]
+
+        result = []
+        for drv in json.loads(
+            self._call_nix(['show-derivation', path])
+        ).values():
+            for output in drv.get('outputs').values():
+                result.append(output.get('path'))
+        return result
+
     def add_path(self, path):
         """Add the closure of all derivations referenced by a store path."""
         if not p.exists(path):
             raise RuntimeError('path `{}` does not exist - cannot load '
                                'derivations referenced from it'.format(path))
         _log.debug('Loading derivations referenced by "%s"', path)
-        deriver = self._find_deriver(path)
-        if self.requisites:
-            for candidate in call(['nix-store', '-qR', deriver]).splitlines():
-                self.update(candidate)
+
+        if self.runtime:
+            for output in self._find_outputs(path):
+                for candidate in map(
+                    # Nix 2.4 also returns `p.get('deriver')`
+                    # like `nix-store -qd` but that path may not exist
+                    lambda p: self._find_deriver(p.get('path')),
+                    json.loads(
+                        self._call_nix(['path-info', '-r', '--json', output])
+                    )
+                ):
+                    self.update(candidate)
         else:
-            self.update(deriver)
+            deriver = self._find_deriver(path)
+            if self.requisites:
+                for candidate in call([
+                    'nix-store', '-qR', deriver
+                ]).splitlines():
+                    self.update(candidate)
+            else:
+                self.update(deriver)
 
     def update(self, drv_path):
         if not drv_path.endswith('.drv'):

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -59,11 +59,12 @@ class Store(object):
                          'nix-command'] + args)
         return call(['nix'] + args)
 
-    def _find_deriver(self, path):
+    def _find_deriver(self, path, qpi_deriver=None):
         if path.endswith('.drv'):
             return path
         # Deriver from QueryPathInfo
-        qpi_deriver = call(['nix-store', '-qd', path]).strip()
+        if qpi_deriver is None:
+            qpi_deriver = call(['nix-store', '-qd', path]).strip()
         _log.debug('qpi_deriver: %s', qpi_deriver)
         if qpi_deriver and qpi_deriver != 'unknown-deriver' and p.exists(
                 qpi_deriver):
@@ -109,13 +110,15 @@ class Store(object):
         if self.closure:
             for output in self._find_outputs(path):
                 for candidate in map(
-                    # We cannot use the `deriver` field because
-                    # like `nix-store -qd` that path may not exist.
+                    # We cannot use the `deriver` field directly because
+                    # like from `nix-store -qd` that path may not exist.
                     # However, we know that if it is not present
                     # the path has no deriver because it is a
                     # derivation input source so we can skip it.
-                    lambda p: self._find_deriver(p.get('path'))
-                        if p.get('deriver') is not None else None,
+                    lambda p: self._find_deriver(
+                                  p.get('path'),
+                                  qpi_deriver=p.get('deriver')
+                              ) if p.get('deriver') is not None else None,
                     json.loads(
                         self._call_nix(['path-info', '-r', '--json', output])
                     )


### PR DESCRIPTION
This PR adds a `--closure` flag that scans the closure of an output path.

Currently vulnix scans all dependencies (unless `--no-requisites` is given) so buildtime-only dependencies are included. Depending on the threat model it may be desirable to scan only runtime dependencies to avoid writing a huge whitelist.

Nix has a `deriver` field in the JSON output of `nix path-info` that I hoped we could use. Unfortunately we run into the same problem as #69 so we still have to shell out to Nix every time that path does not exist.