### PR TITLE
feat: support manifest.json version 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support profile manifest.json version 2
 
 
 1.10.1 (2022-02-06)

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -32,7 +32,7 @@ class Store(object):
                 json_manifest_path))
             with open(json_manifest_path, 'r') as f:
                 json_manifest = json.load(f)
-            if json_manifest['version'] > 1:
+            if json_manifest['version'] > 2:
                 raise RuntimeError(
                     ('Profile manifest.json version {} ' +
                      'not yet supported').format(


### PR DESCRIPTION
version 2 doesn't change anything that is relevant to vulnix, so this is trivial.

i did encounter some errors where vulnix was unable to find the derivers of certain paths¹, but i assume this is an inherent limitation of nix.

1: packages installed via nix-env before transitioning to nix profile