### PR TITLE
Enable flake support

### DIFF
--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -56,7 +56,7 @@ class Store(object):
         if self.experimental_flag_needed:
             return call(['nix',
                          '--experimental-features',
-                         'nix-command'] + args)
+                         'nix-command flakes'] + args)
         return call(['nix'] + args)
 
     def _find_deriver(self, path, qpi_deriver=None):


### PR DESCRIPTION
When using flakes `vulnix -C ./result` errors and complains that `Nix feature 'flakes' is disabled`. Add flakes to `extra-experimental-features` to fix this.

See:
```
error: experimental Nix feature 'flakes' is disabled; use '--extra-experimental-features flakes' to override
Traceback (most recent call last):
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/bin/.vulnix-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/x945cn634yr39bbjz5rv7my5yj0gx6ry-python3.11-click-8.1.7/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/x945cn634yr39bbjz5rv7my5yj0gx6ry-python3.11-click-8.1.7/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/nix/store/x945cn634yr39bbjz5rv7my5yj0gx6ry-python3.11-click-8.1.7/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/x945cn634yr39bbjz5rv7my5yj0gx6ry-python3.11-click-8.1.7/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/lib/python3.11/site-packages/vulnix/main.py", line 157, in main
    populate_store(store, gc_roots, profile,  paths)
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/lib/python3.11/site-packages/vulnix/main.py", line 60, in populate_store
    store.add_path(path)
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/lib/python3.11/site-packages/vulnix/nix.py", line 123, in add_path
    self._call_nix(['path-info', '-r', '--json', output])
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/lib/python3.11/site-packages/vulnix/nix.py", line 57, in _call_nix
    return call(['nix',
           ^^^^^^^^^^^^
  File "/nix/store/wlxjs6pxn9bw46kfxq5p8pxf6kv7rpiz-vulnix-1.10.1-unstable-2024-04-02/lib/python3.11/site-packages/vulnix/utils.py", line 15, in call
    output = subprocess.check_output(cmd, stderr=capture)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['nix', '--experimental-features', 'nix-command', 'path-info', '-r', '--json', 'result']' returned non-zero exit status 1.
```