### PR TITLE
Fix default.nix after nixpkgs vulnix path changed

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,11 +2,8 @@
 , pkgs ? import nixpkgs {}
 , lib ? pkgs.lib
 }:
-
 # uses build in upstream nixpkgs
-(pkgs.callPackage "${nixpkgs}/pkgs/tools/security/vulnix" {
-  python3Packages = pkgs.python311Packages;
-}).overrideAttrs (
+(pkgs.vulnix).overrideAttrs (
   old: rec {
     src = lib.cleanSource ./.;
     version = lib.removeSuffix "\n" (builtins.readFile ./VERSION);


### PR DESCRIPTION
Vulnix path in nixpkgs was changed with https://github.com/NixOS/nixpkgs/pull/354531. After that change, the vulnix path hardcoded in `default.nix` no longer matches `{nixpkgs}/pkgs/tools/security/vulnix` which broke the `default.nix` in vulnix repo.

This PR fixes the issue by referencing nixpkgs vulnix with `pkgs.vulnix` instead of hardcoding the path.