### PR TITLE
Remove new maintainer needed announcement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-New maintainer needed! See https://github.com/flyingcircusio/vulnix/issues/87
-for details.
-
-
 Nix(OS) vulnerability scanner
 =============================
 


### PR DESCRIPTION
Remove the link to https://github.com/flyingcircusio/vulnix/issues/87 from the project README.