### PR TITLE
Github actions: Apply security best practices

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Vulnix CI
 on:
   [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   flake-default:
     strategy:
@@ -10,15 +13,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: cachix/install-nix-action@v30
+    - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: cachix/cachix-action@v15
+    - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
       with:
         name: nix-community
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Nix build
       run: nix-build --show-trace
     - name: Nix flake check


### PR DESCRIPTION
Apply the following security hardening for github actions as suggested by https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions:

- Set minimum token permissions for the GITHUB_TOKEN
- Pin actions to full length commit sha
- Keep actions up to date with Dependabot
