### PR TITLE
Stop using deprecated python pkg_resources module

### DIFF
--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -17,11 +17,11 @@ Invoke after nix-build:  vulnix ./result
 See vulnix --help for a full list of options.
 """
 
+import importlib.metadata
 import logging
 import sys
 
 import click
-import pkg_resources
 
 from .nix import Store
 from .nvd import DEFAULT_CACHE_DIR, DEFAULT_MIRROR, NVD
@@ -180,7 +180,12 @@ def main(
     # pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
     # pylint: disable=too-many-locals,too-many-branches
     if version:
-        print("vulnix " + pkg_resources.get_distribution("vulnix").version)
+        versionstr = "0.0.0-unknown"
+        try:
+            versionstr = importlib.metadata.version("vulnix")
+        except importlib.metadata.PackageNotFoundError:
+            pass
+        print("vulnix " + versionstr)
         sys.exit(0)
 
     if closure:

--- a/src/vulnix/tests/conftest.py
+++ b/src/vulnix/tests/conftest.py
@@ -2,44 +2,41 @@ import hashlib
 import http.server
 import json
 import os
-import os.path as p
 import threading
 from http import HTTPStatus
+from pathlib import Path
 
-import pkg_resources
 import pytest
 
 from vulnix.nvd import NVD
 from vulnix.whitelist import Whitelist
 
+fixtures_path = Path(os.path.dirname(os.path.realpath(__file__))) / "fixtures"
+
 
 def load(cve):
-    return json.loads(
-        pkg_resources.resource_string("vulnix", f"tests/fixtures/{cve}.json")
-    )
+    return json.loads((fixtures_path / f"{cve}.json").read_text())
 
 
 @pytest.fixture
 def whitelist_toml():
-    return pkg_resources.resource_stream("vulnix", "tests/fixtures/whitelist.toml")
+    return (fixtures_path / "whitelist.toml").open()
 
 
 @pytest.fixture
 def whitelist_yaml():
-    return pkg_resources.resource_stream("vulnix", "tests/fixtures/whitelist.yaml")
+    return (fixtures_path / "whitelist.yaml").open()
 
 
 @pytest.fixture
 def whitelist():
-    return Whitelist.load(
-        pkg_resources.resource_stream("vulnix", "tests/fixtures/whitelist.toml")
-    )
+    return Whitelist.load((fixtures_path / "whitelist.toml").open())
 
 
 class RequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         """Serve a GET request from the fixtures directory"""
-        fn = p.join(p.dirname(__file__), "fixtures", self.path[1:])
+        fn = os.path.join(os.path.dirname(__file__), "fixtures", self.path[1:])
         print("path=", fn)
         try:
             with open(fn, "rb") as f:

--- a/src/vulnix/tests/store_test.py
+++ b/src/vulnix/tests/store_test.py
@@ -1,4 +1,6 @@
-import pkg_resources
+import os
+from pathlib import Path
+
 import pytest
 
 from vulnix.derivation import Derive
@@ -7,7 +9,8 @@ from vulnix.nix import Store
 
 @pytest.fixture(name="json")
 def fixture_json():
-    return pkg_resources.resource_stream("vulnix", "tests/fixtures/pkgs.json")
+    fixtures_path = Path(os.path.dirname(os.path.realpath(__file__))) / "fixtures"
+    return (fixtures_path / "pkgs.json").open()
 
 
 def test_load_json(json):

--- a/src/vulnix/tests/test_derivation.py
+++ b/src/vulnix/tests/test_derivation.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
+from pathlib import Path
 
-import pkg_resources
 import pytest
 
 from vulnix.derivation import Derive, SkipDrv, load, split_name
@@ -11,9 +11,8 @@ V = Vulnerability
 
 
 def drv(fixture):
-    return load(
-        pkg_resources.resource_filename("vulnix", f"tests/fixtures/{fixture}.drv")
-    )
+    fixtures_path = Path(os.path.dirname(os.path.realpath(__file__))) / "fixtures"
+    return load((fixtures_path / f"{fixture}.drv").as_posix())
 
 
 def test_load_drv_explicit_version():

--- a/src/vulnix/tests/vulnerability_test.py
+++ b/src/vulnix/tests/vulnerability_test.py
@@ -1,6 +1,6 @@
 import json
-
-import pkg_resources
+import os
+from pathlib import Path
 
 from vulnix.vulnerability import Node, Vulnerability
 
@@ -8,9 +8,8 @@ V = Vulnerability
 
 
 def load(cve):
-    return json.loads(
-        pkg_resources.resource_string("vulnix", f"tests/fixtures/{cve}.json")
-    )
+    fixtures_path = Path(os.path.dirname(os.path.realpath(__file__))) / "fixtures"
+    return json.loads((fixtures_path / f"{cve}.json").read_text())
 
 
 def test_parse_single_matches():


### PR DESCRIPTION
Stop using deprecated python module `pkg_resources`.
This removes the related warnings in the vulnix output:

```
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```