### PR TITLE
Support foreign Nix store

### DIFF
--- a/doc/vulnix.1.md
+++ b/doc/vulnix.1.md
@@ -27,6 +27,12 @@ should not be reported.
 
 ## OPTIONS
 
+* `-g`, `--guest`=<PATH>:
+  Scan a foreign Nix installation rooted at <PATH>. Paths passed as positional
+  arguments or with `--profile` must be absolute paths as seen inside the guest,
+  such as _/nix/store/..._ or _/nix/var/nix/profiles/default_; they are not host
+  paths. `--system` and `--gc-roots` likewise inspect the guest installation.
+
 * `-S`, `--system`:
   Scans the current system defined as transitive closure of
   _/run/current-system_.

--- a/src/vulnix/main.py
+++ b/src/vulnix/main.py
@@ -19,6 +19,7 @@ See vulnix --help for a full list of options.
 
 import importlib.metadata
 import logging
+import os.path as p
 import sys
 
 import click
@@ -75,6 +76,12 @@ def run(nvd, store):
 
 @click.command("vulnix")
 # what to scan
+@click.option(
+    "-g",
+    "--guest",
+    type=click.Path(exists=True, file_okay=False),
+    help="Guest sysroot path that contains nix store.",
+)
 @click.option("-S", "--system", is_flag=True, help="Scan the current system.")
 @click.option(
     "-G",
@@ -85,14 +92,14 @@ def run(nvd, store):
 @click.option(
     "-p",
     "--profile",
-    type=click.Path(exists=True),
+    type=click.Path(),  # might be a guest path
     multiple=True,
     help="Scan this profile (eg: ~/.nix-profile)",
 )
 @click.option(
     "-f", "--from-file", type=click.File(mode="r"), help="Read derivations from file"
 )
-@click.argument("path", nargs=-1, type=click.Path(exists=True))
+@click.argument("path", nargs=-1, type=click.Path())
 # modify operation
 @click.option(
     "-w",
@@ -159,6 +166,7 @@ def run(nvd, store):
 )
 def main(
     verbose,
+    guest,
     gc_roots,
     system,
     from_file,
@@ -178,7 +186,20 @@ def main(
     notfixed,
 ):
     # pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
-    # pylint: disable=too-many-locals,too-many-branches
+    # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    if guest is None:
+        for path_arg in path:
+            if not p.exists(path_arg):
+                raise click.BadParameter(
+                    f"Path '{path_arg}' does not exist.", param_hint="'[PATH]...'"
+                )
+        for profile_arg in profile:
+            if not p.exists(profile_arg):
+                raise click.BadParameter(
+                    f"Path '{profile_arg}' does not exist.",
+                    param_hint="'-p' / '--profile'",
+                )
+
     if version:
         versionstr = "0.0.0-unknown"
         try:
@@ -208,7 +229,7 @@ def main(
             for wl in wh_sources:
                 whitelist.merge(Whitelist.load(wl))
         with Timer("Load derivations"):
-            store = Store(requisites, closure)
+            store = Store(requisites, closure, guest)
             if from_file:
                 if from_file.name.endswith(".json"):
                     _log.debug("loading packages.json")

--- a/src/vulnix/nix.py
+++ b/src/vulnix/nix.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import os.path as p
 import subprocess
 
@@ -15,9 +16,10 @@ class DeriverLookupError(RuntimeError):
 
 
 class Store:
-    def __init__(self, requisites=True, closure=False):
+    def __init__(self, requisites=True, closure=False, guest=None):
         self.requisites = requisites
         self.closure = closure
+        self.guest = p.abspath(guest) if guest else None
         self.derivations = set()
         self.experimental_flag_needed = None
 
@@ -27,13 +29,14 @@ class Store:
         Note that this usually includes old system versions.
         """
         _log.debug("Loading all live derivations")
-        for d in call(["nix-store", "--gc", "--print-live"]).splitlines():
+        for d in self._call_nixlike(["nix-store", "--gc", "--print-live"]).splitlines():
             self.update(d)
 
     # pylint: disable=too-many-branches
     def add_profile(self, profile):
         """Add derivations found in this nix profile."""
-        json_manifest_path = p.join(profile, "manifest.json")
+        host_profile = self._host_path(profile)
+        json_manifest_path = p.join(host_profile, "manifest.json")
         if p.exists(json_manifest_path):
             _log.debug("Loading derivations from %s", json_manifest_path)
             with open(json_manifest_path, "r", encoding="utf-8") as f:
@@ -68,11 +71,18 @@ class Store:
                     for path in element["storePaths"]:
                         self.add_path(path)
         else:
+            if not p.exists(host_profile):
+                raise RuntimeError(f"profile `{profile}` does not exist")
             _log.debug("Loading derivations from user profile %s", profile)
-            for line in call(
-                ["nix-env", "-q", "--out-path", "--profile", profile]
+            for line in self._call_nixlike(
+                ["nix-env", "-q", "--out-path", "--profile", host_profile]
             ).splitlines():
                 self.add_path(line.split()[1])
+
+    def _call_nixlike(self, args, log_stderr=True):
+        if self.guest is not None:
+            args += ["--store", f"local?root={self.guest}"]
+        return call(args, log_stderr=log_stderr)
 
     def _call_nix(self, args, log_stderr=True):
         if self.experimental_flag_needed is None:
@@ -81,11 +91,46 @@ class Store:
             )
 
         if self.experimental_flag_needed:
-            return call(
+            return self._call_nixlike(
                 ["nix", "--experimental-features", "nix-command flakes"] + args,
                 log_stderr=log_stderr,
             )
-        return call(["nix"] + args, log_stderr=log_stderr)
+        return self._call_nixlike(["nix"] + args, log_stderr=log_stderr)
+
+    def _host_path(self, path):
+        if self.guest is None:
+            return path
+        if not p.isabs(path):
+            raise RuntimeError(f"path `{path}` must be absolute")
+
+        # Path relative to the guest root (logical "/" == self.guest).
+        remaining = path.lstrip("/")
+        for _ in range(16):  # Reject paths requiring 16 or more symlink rewrites.
+            parts = []
+            while remaining:
+                component, _, remaining = remaining.partition("/")
+                if component == "..":
+                    # At logical root, ".." is a no-op (/.. == /).
+                    if parts:
+                        parts.pop()
+                elif component and component != ".":
+                    parts.append(component)
+                    host_path = p.join(self.guest, *parts)
+                    if p.islink(host_path):
+                        link_target = os.readlink(host_path)
+                        if p.isabs(link_target):
+                            base = link_target.lstrip("/")
+                        elif parts[:-1]:
+                            base = f"{'/'.join(parts[:-1])}/{link_target}"
+                        else:
+                            base = link_target
+                        if remaining and not remaining.startswith("/"):
+                            remaining = "/" + remaining
+                        remaining = base + remaining
+                        break  # Restart walk with rewritten remaining path.
+            else:
+                return p.join(self.guest, *parts)
+        raise RuntimeError(f"symlink chain is too deep: {path}")
 
     @staticmethod
     def _absolute_store_path(path):
@@ -140,15 +185,21 @@ class Store:
             return path
         # Deriver from QueryPathInfo
         if qpi_deriver == "undef":
-            qpi_deriver = call(["nix-store", "-qd", path]).strip()
+            qpi_deriver = self._call_nixlike(
+                ["nix-store", "-qd", path], log_stderr=log_stderr
+            ).strip()
         _log.debug("qpi_deriver: %s", qpi_deriver)
-        if qpi_deriver and qpi_deriver != "unknown-deriver" and p.exists(qpi_deriver):
+        if (
+            qpi_deriver
+            and qpi_deriver != "unknown-deriver"
+            and p.exists(self._host_path(qpi_deriver))
+        ):
             return qpi_deriver
         # Deriver from QueryValidDerivers
         qvd_derivations = self._show_derivations(path, log_stderr=log_stderr)
         qvd_deriver = next(iter(qvd_derivations), None)
         _log.debug("qvd_deriver: %s", qvd_deriver)
-        if qvd_deriver and p.exists(qvd_deriver):
+        if qvd_deriver and p.exists(self._host_path(qvd_deriver)):
             return qvd_deriver
 
         error = ""
@@ -189,12 +240,15 @@ class Store:
     def add_path(self, path):
         # pylint: disable=too-many-branches
         """Add the closure of all derivations referenced by a store path."""
-        if not p.exists(path):
+        host_path = self._host_path(path)
+        if not p.exists(host_path):
             raise RuntimeError(
-                f"path `{path}` does not exist - cannot load "
+                f"path `{host_path}` does not exist - cannot load "
                 "derivations referenced from it"
             )
-        _log.debug('Loading derivations referenced by "%s"', path)
+        if self.guest is not None:
+            path = "/" + p.relpath(host_path, self.guest)
+        _log.debug('Loading derivations referenced by "%s"', host_path)
 
         if self.closure:
             for output in self._find_outputs(path):
@@ -220,7 +274,9 @@ class Store:
         else:
             deriver = self._find_deriver(path)
             if self.requisites:
-                for candidate in call(["nix-store", "-qR", deriver]).splitlines():
+                for candidate in self._call_nixlike(
+                    ["nix-store", "-qR", deriver]
+                ).splitlines():
                     self.update(candidate)
             else:
                 self.update(deriver)
@@ -229,7 +285,7 @@ class Store:
         if not drv_path or not drv_path.endswith(".drv"):
             return
         try:
-            drv_obj = load(drv_path)
+            drv_obj = load(self._host_path(drv_path))
         except SkipDrv:
             return
         self.derivations.add(drv_obj)

--- a/src/vulnix/tests/main_test.py
+++ b/src/vulnix/tests/main_test.py
@@ -1,0 +1,34 @@
+import pytest
+from click.testing import CliRunner
+
+from vulnix.main import main
+
+
+@pytest.mark.parametrize(
+    ("option", "parameter"),
+    [(None, "'[PATH]...'"), ("--profile", "'-p' / '--profile'")],
+)
+def test_cli_validation_allows_guest_paths(tmp_path, option, parameter):
+    missing = str(tmp_path / "missing")
+    scan_args = [missing] if option is None else [option, missing]
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["--version", *scan_args])
+
+    assert result.exit_code == 2
+    assert f"Invalid value for {parameter}" in result.output
+    assert f"Path '{missing}' does not exist." in result.output
+
+    result = runner.invoke(main, ["--guest", str(tmp_path), "--version", *scan_args])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("vulnix ")
+
+
+def test_missing_guest_profile_fails_scan(tmp_path, caplog):
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["--guest", str(tmp_path), "--profile", "/missing"])
+
+    assert result.exit_code == 2
+    assert "profile `/missing` does not exist" in caplog.text

--- a/src/vulnix/tests/store_test.py
+++ b/src/vulnix/tests/store_test.py
@@ -30,6 +30,50 @@ def test_load_json(json):
     )
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "expected_log_stderr"),
+    [({}, True), ({"log_stderr": False}, False)],
+)
+def test_call_nixlike_adds_guest_store_and_forwards_log_stderr(
+    monkeypatch, tmp_path, kwargs, expected_log_stderr
+):
+    calls = []
+
+    def fake_call(args, log_stderr=True):
+        calls.append((args, log_stderr))
+        return ""
+
+    monkeypatch.setattr("vulnix.nix.call", fake_call)
+    store = Store(requisites=False, guest=str(tmp_path))
+
+    store._call_nixlike(["nix-store", "-q"], **kwargs)
+
+    assert calls == [
+        (
+            ["nix-store", "-q", "--store", f"local?root={tmp_path}"],
+            expected_log_stderr,
+        )
+    ]
+
+
+def test_add_guest_profile_uses_host_path(monkeypatch, tmp_path):
+    profile = "/nix/var/nix/profiles/default"
+    host_profile = tmp_path / profile.removeprefix("/")
+    host_profile.mkdir(parents=True)
+    calls = []
+
+    def fake_call_nixlike(args):
+        calls.append(args)
+        return ""
+
+    store = Store(requisites=False, guest=str(tmp_path))
+    monkeypatch.setattr(store, "_call_nixlike", fake_call_nixlike)
+
+    store.add_profile(profile)
+
+    assert calls == [["nix-env", "-q", "--out-path", "--profile", str(host_profile)]]
+
+
 def test_find_deriver_supports_wrapped_show_derivation_json(monkeypatch):
     s = Store(requisites=False)
     drv_path = "/nix/store/good.drv"
@@ -44,6 +88,50 @@ def test_find_deriver_supports_wrapped_show_derivation_json(monkeypatch):
     monkeypatch.setattr("vulnix.nix.p.exists", lambda path: path == drv_path)
 
     assert s._find_deriver("/nix/store/good-out", "unknown-deriver") == drv_path
+
+
+def test_guest_path_scan_loads_guest_derivation(monkeypatch, tmp_path):
+    output_path = tmp_path / "nix/store/pkg-out"
+    drv_path = tmp_path / "nix/store/pkg.drv"
+    output_path.mkdir(parents=True)
+    drv_path.touch()
+    loaded = []
+
+    def fake_call_nixlike(args, **_kwargs):
+        assert args == ["nix-store", "-qd", "/nix/store/pkg-out"]
+        return "/nix/store/pkg.drv\n"
+
+    def fake_load(path):
+        loaded.append(path)
+        return Derive(name="pkg")
+
+    store = Store(requisites=False, guest=str(tmp_path))
+    monkeypatch.setattr(store, "_call_nixlike", fake_call_nixlike)
+    monkeypatch.setattr("vulnix.nix.load", fake_load)
+
+    store.add_path("/nix/store/pkg-out")
+
+    assert loaded == [str(drv_path)]
+
+
+def test_find_deriver_suppresses_stderr_for_all_optional_queries(monkeypatch):
+    store = Store(requisites=False)
+
+    def fake_call_nixlike(args, log_stderr=True):
+        assert args == ["nix-store", "-qd", "/nix/store/pkg-out"]
+        assert log_stderr is False
+        return "unknown-deriver\n"
+
+    def fake_show_derivations(path, log_stderr=True):
+        assert path == "/nix/store/pkg-out"
+        assert log_stderr is False
+        return {}
+
+    monkeypatch.setattr(store, "_call_nixlike", fake_call_nixlike)
+    monkeypatch.setattr(store, "_show_derivations", fake_show_derivations)
+
+    with pytest.raises(DeriverLookupError):
+        store._find_deriver("/nix/store/pkg-out", log_stderr=False)
 
 
 def test_find_outputs_supports_wrapped_show_derivation_json(monkeypatch):
@@ -94,6 +182,9 @@ def test_add_profile_reevaluates_wrapped_deriver_lookup_errors(monkeypatch, tmp_
             raise subprocess.CalledProcessError(1, args)
         raise AssertionError(f"unexpected nix command: {args}")
 
+    def fake_call_nix_store(cmd, log_stderr=True):  # pylint: disable=unused-argument
+        return "/nix/store/missing.drv\n"
+
     def fake_exists(path):
         return path in {
             str(manifest_path),
@@ -102,7 +193,7 @@ def test_add_profile_reevaluates_wrapped_deriver_lookup_errors(monkeypatch, tmp_
 
     monkeypatch.setattr(s, "_call_nix", fake_call_nix)
     monkeypatch.setattr(s, "update", updated.append)
-    monkeypatch.setattr("vulnix.nix.call", lambda _args: "/nix/store/missing.drv\n")
+    monkeypatch.setattr("vulnix.nix.call", fake_call_nix_store)
     monkeypatch.setattr("vulnix.nix.p.exists", fake_exists)
 
     s.add_profile(str(tmp_path))
@@ -291,3 +382,112 @@ def test_closure_skips_outputs_without_loadable_derivers(monkeypatch, caplog):
     ]
     assert skipped
     assert all(record.levelno == logging.DEBUG for record in skipped)
+
+
+def test_host_path_keeps_symlink_resolution_under_guest(tmp_path):
+    cases = [
+        (
+            "relative-symlink",
+            "/nix/var/nix/profiles/default",
+            lambda guest: (
+                (guest / "nix/var/nix/profiles").mkdir(parents=True),
+                (guest / "nix/var/nix/profiles/default").symlink_to(
+                    "../../../../../../etc/passwd"
+                ),
+            ),
+            ("etc", "passwd"),
+        ),
+        (
+            "absolute-symlink",
+            "/nix/escape",
+            lambda guest: (
+                (guest / "nix").mkdir(),
+                (guest / "nix/escape").symlink_to("/../../../etc/shadow"),
+            ),
+            ("etc", "shadow"),
+        ),
+        (
+            "logical-dotdot",
+            "/nix/../etc/passwd",
+            lambda guest: None,
+            ("etc", "passwd"),
+        ),
+        (
+            "intermediate-symlink",
+            "/nix/store/foo",
+            lambda guest: (
+                (guest / "nix").symlink_to("var"),
+                (guest / "var/store").mkdir(parents=True),
+            ),
+            ("var", "store", "foo"),
+        ),
+        (
+            "dot-components",
+            "/nix/./var/../var/nix/profiles/default",
+            lambda guest: (guest / "nix/var/nix/profiles").mkdir(parents=True),
+            ("nix", "var", "nix", "profiles", "default"),
+        ),
+        (
+            "symlink-chain",
+            "/a/c",
+            lambda guest: (
+                (guest / "a").symlink_to("b"),
+                (guest / "b").symlink_to("../../etc/chain"),
+            ),
+            ("etc", "chain", "c"),
+        ),
+    ]
+
+    for name, logical, prepare, expected_parts in cases:
+        guest = tmp_path / name
+        guest.mkdir()
+        if prepare is not None:
+            prepare(guest)
+        store = Store(requisites=False, guest=str(guest))
+        assert store._host_path(logical) == str(guest.joinpath(*expected_parts))
+
+
+def test_host_path_rejects_relative_guest_path(tmp_path):
+    store = Store(requisites=False, guest=str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="must be absolute"):
+        store._host_path("nix/store/pkg")
+
+
+def test_guest_symlink_path_is_resolved_before_deriver_query(monkeypatch, tmp_path):
+    guest = tmp_path / "guest"
+    target = guest / "nix/store/system"
+    link = guest / "nix/var/nix/gcroots/current-system"
+    target.mkdir(parents=True)
+    link.parent.mkdir(parents=True)
+    link.symlink_to("/nix/store/system")
+
+    store = Store(requisites=False, guest=str(guest))
+    queried = []
+    monkeypatch.setattr(store, "_find_deriver", queried.append)
+
+    store.add_path("/nix/var/nix/gcroots/current-system")
+
+    assert queried == ["/nix/store/system"]
+
+
+def test_guest_symlink_path_is_resolved_before_closure_query(monkeypatch, tmp_path):
+    guest = tmp_path / "guest"
+    target = guest / "nix/store/system"
+    link = guest / "nix/var/nix/gcroots/current-system"
+    target.mkdir(parents=True)
+    link.parent.mkdir(parents=True)
+    link.symlink_to("/nix/store/system")
+
+    store = Store(requisites=False, closure=True, guest=str(guest))
+    queried = []
+
+    def fake_call_nix(args, **_kwargs):
+        queried.append(args)
+        return "[]"
+
+    monkeypatch.setattr(store, "_call_nix", fake_call_nix)
+
+    store.add_path("/nix/var/nix/gcroots/current-system")
+
+    assert queried == [["path-info", "-r", "--json", "/nix/store/system"]]


### PR DESCRIPTION
## Summary
Adds a `--guest` / `-g` option so vulnix can scan a Nix store that lives under another filesystem root (e.g. a container/mounted VM or backup), not only the host’s default `/nix/store`.

## Motivation
Paths like profiles and store objects may exist only under that guest root. Without targeting that store, `nix-store` / `nix` and file checks run against the wrong tree and scans fail or miss data.

## Changes
Store: optional guest sysroot; when set, `nix` and `nix-store` are invoked with `--store local?root=<guest>`.

Path handling: profile manifests, derivation paths, and existence checks are resolved on the guest tree (`_host_path` / `_host_drv_path`), including limited symlink following for profiles.

`--profile`: `click.Path(exists=True)` is relaxed because the profile symlink target may exist only under guest sysroot.

## Usage
```
vulnix --guest /mnt/guest-root -G
```
See [agentsandbox](https://github.com/amamival/agentsandbox/blob/221278bc330dac320e1b744c406d2abd0c38443f/src/main.rs#L1386) for the actual usage.

## Disclosure
The work is generated with Codex GPT-5.4 and Cursor Composer-2. Manually reviewed and edited.